### PR TITLE
Add `getvalue`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AlgebraicInterfaces"
 uuid = "23cfdc9f-0504-424a-be1f-4892b28e2f0c"
 authors = ["AlgebraicJulia developers"]
-version = "0.1.3"
+version = "0.1.4"
 
 [compat]
 julia = "1"

--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ Contains declarations for the following functions:
 - Monoidal: categories: `munit`, `mcompose`
 - Operads: `ocompose`, `oapply`
 - Attributed CSets: `attr`, `attrtypes`
-- General algebra: `generators`, `equations`
+- Generic functions: `generators`, `equations`, `getvalue`

--- a/src/AlgebraicInterfaces.jl
+++ b/src/AlgebraicInterfaces.jl
@@ -1,6 +1,6 @@
 module AlgebraicInterfaces
 export dom, codom, compose, id, Ob, ob, Hom, hom, munit, mcompose, ocompose, 
-        oapply, attr, attrtype
+        oapply, attr, attrtype, generators, equations, getvalue
 
 # Theory of categories 
 function dom end

--- a/src/AlgebraicInterfaces.jl
+++ b/src/AlgebraicInterfaces.jl
@@ -28,5 +28,6 @@ function attrtype end
 # Generic functions
 function generators end
 function equations end
+function getvalue end
 
 end # module


### PR DESCRIPTION
`getvalue` is used in many places in GATlab, but it is also the appropriate name for a method to get the wrapped value of an `AttrVar` in ACSets.jl.